### PR TITLE
add a websocket callback: on_disconnected()

### DIFF
--- a/binance/websocket/binance_socket_manager.py
+++ b/binance/websocket/binance_socket_manager.py
@@ -21,6 +21,7 @@ class BinanceSocketManager(threading.Thread):
         on_error=None,
         on_ping=None,
         on_pong=None,
+        on_disconnected=None,
         logger=None,
         proxies: Optional[dict] = None,
     ):
@@ -35,6 +36,7 @@ class BinanceSocketManager(threading.Thread):
         self.on_ping = on_ping
         self.on_pong = on_pong
         self.on_error = on_error
+        self.on_disconnected = on_disconnected
         self.proxies = proxies
 
         self._proxy_params = parse_proxies(proxies) if proxies else {}
@@ -69,9 +71,10 @@ class BinanceSocketManager(threading.Thread):
             except WebSocketException as e:
                 if isinstance(e, WebSocketConnectionClosedException):
                     self.logger.error("Lost websocket connection")
+                    self._callback(self.on_disconnected)
                 else:
                     self.logger.error("Websocket exception: {}".format(e))
-                raise e
+                    raise e
             except Exception as e:
                 self.logger.error("Exception in read_data: {}".format(e))
                 raise e

--- a/binance/websocket/cm_futures/websocket_client.py
+++ b/binance/websocket/cm_futures/websocket_client.py
@@ -13,6 +13,7 @@ class CMFuturesWebsocketClient(BinanceWebsocketClient):
         on_error=None,
         on_ping=None,
         on_pong=None,
+        on_disconnected=None,
         is_combined=False,
         proxies: Optional[dict] = None,
     ):
@@ -28,6 +29,7 @@ class CMFuturesWebsocketClient(BinanceWebsocketClient):
             on_error=on_error,
             on_ping=on_ping,
             on_pong=on_pong,
+            on_disconnected=on_disconnected,
             proxies=proxies,
         )
 

--- a/binance/websocket/um_futures/websocket_client.py
+++ b/binance/websocket/um_futures/websocket_client.py
@@ -13,6 +13,7 @@ class UMFuturesWebsocketClient(BinanceWebsocketClient):
         on_error=None,
         on_ping=None,
         on_pong=None,
+        on_disconnected=None,
         is_combined=False,
         proxies: Optional[dict] = None,
     ):
@@ -28,6 +29,7 @@ class UMFuturesWebsocketClient(BinanceWebsocketClient):
             on_error=on_error,
             on_ping=on_ping,
             on_pong=on_pong,
+            on_disconnected=on_disconnected,
             proxies=proxies,
         )
 

--- a/binance/websocket/websocket_client.py
+++ b/binance/websocket/websocket_client.py
@@ -20,6 +20,7 @@ class BinanceWebsocketClient:
         on_error=None,
         on_ping=None,
         on_pong=None,
+        on_disconnected=None,
         logger=None,
         proxies: Optional[dict] = None,
     ):
@@ -34,6 +35,7 @@ class BinanceWebsocketClient:
             on_error,
             on_ping,
             on_pong,
+            on_disconnected,
             logger,
             proxies,
         )
@@ -51,6 +53,7 @@ class BinanceWebsocketClient:
         on_error,
         on_ping,
         on_pong,
+        on_disconnected,
         logger,
         proxies,
     ):
@@ -62,6 +65,7 @@ class BinanceWebsocketClient:
             on_error=on_error,
             on_ping=on_ping,
             on_pong=on_pong,
+            on_disconnected=on_disconnected,
             logger=logger,
             proxies=proxies,
         )


### PR DESCRIPTION
I want to reconnect to websocket server, but can't catch the disconnected exception raised by the BinanceSocketManager thread. So add the on_disconnected() callback to solve this problem.