### PR TITLE
fix url_path in list_all_convert_pairs

### DIFF
--- a/binance/um_futures/convert.py
+++ b/binance/um_futures/convert.py
@@ -17,7 +17,7 @@ def list_all_convert_pairs(self, **kwargs):
     |
     """
 
-    url_path = "/sapi/v1/asset/assetDividend"
+    url_path = "/fapi/v1/convert/exchangeInfo"
     params = {**kwargs}
 
     return self.sign_request("GET", url_path, params)


### PR DESCRIPTION
The value of the variable `url_path` in the function `list_all_convert_pairs` is incorrect.