### PR TITLE
bug fix: fix parameter validation for account.get_open_orders only sy…

### DIFF
--- a/binance/um_futures/account.py
+++ b/binance/um_futures/account.py
@@ -479,10 +479,9 @@ def get_open_orders(
         check_required_parameters(
             [
                 [symbol, "symbol"],
-                [orderId, "orderId"],
-                [origClientOrderId, "origClientOrderId"],
             ]
-        )
+        ) 
+        params = {"symbol": symbol}
     elif orderId:
         params = {"symbol": symbol, "orderId": orderId, **kwargs}
     else:


### PR DESCRIPTION
bug fix: fix parameter validation for account.get_open_orders only symbol is mandatory

https://developers.binance.com/docs/derivatives/usds-margined-futures/trade/rest-api/Query-Current-Open-Order